### PR TITLE
fix sqs required region name

### DIFF
--- a/eb_sqs/aws/sqs_queue_client.py
+++ b/eb_sqs/aws/sqs_queue_client.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import boto3
+from botocore.config import Config
 from botocore.exceptions import ClientError
 
 from eb_sqs import settings
@@ -10,7 +11,10 @@ from eb_sqs.worker.queue_client import QueueClient, QueueDoesNotExistException, 
 class SqsQueueClient(QueueClient):
     def __init__(self):
         # type: () -> None
-        self.sqs = boto3.resource('sqs', region_name=settings.AWS_REGION)
+        self.sqs = boto3.resource('sqs',
+                                  region_name=settings.AWS_REGION,
+                                  config=Config(retries={'max_attempts': settings.AWS_MAX_RETRIES})
+                                  )
         self.queue_cache = {}
 
     def _get_queue(self, queue_name):

--- a/eb_sqs/aws/sqs_queue_client.py
+++ b/eb_sqs/aws/sqs_queue_client.py
@@ -10,7 +10,7 @@ from eb_sqs.worker.queue_client import QueueClient, QueueDoesNotExistException, 
 class SqsQueueClient(QueueClient):
     def __init__(self):
         # type: () -> None
-        self.sqs = boto3.resource('sqs')
+        self.sqs = boto3.resource('sqs', region_name=settings.AWS_REGION)
         self.queue_cache = {}
 
     def _get_queue(self, queue_name):

--- a/eb_sqs/tests/aws/tests_aws_queue_client.py
+++ b/eb_sqs/tests/aws/tests_aws_queue_client.py
@@ -6,13 +6,14 @@ import boto3
 import time
 from moto import mock_sqs
 
+from eb_sqs import settings
 from eb_sqs.aws.sqs_queue_client import SqsQueueClient
 
 
 class AwsQueueClientTest(TestCase):
     @mock_sqs()
     def test_add_message(self):
-        sqs = boto3.resource('sqs')
+        sqs = boto3.resource('sqs', region_name=settings.AWS_REGION)
         queue = sqs.create_queue(QueueName='eb-sqs-default')
 
         queue_client = SqsQueueClient()
@@ -25,7 +26,7 @@ class AwsQueueClientTest(TestCase):
     @mock_sqs()
     def test_add_message_delayed(self):
         delay = 1
-        sqs = boto3.resource('sqs')
+        sqs = boto3.resource('sqs', region_name=settings.AWS_REGION)
         queue = sqs.create_queue(QueueName='eb-sqs-default')
         queue_client = SqsQueueClient()
 

--- a/eb_sqs/tests/aws/tests_aws_queue_client.py
+++ b/eb_sqs/tests/aws/tests_aws_queue_client.py
@@ -14,7 +14,7 @@ from eb_sqs.worker.queue_client import QueueDoesNotExistException
 class AwsQueueClientTest(TestCase):
     @mock_sqs()
     def test_add_message(self):
-        sqs = boto3.resource('sqs', region_name=settings.AWS_REGION)
+        sqs = boto3.resource('sqs')
         queue = sqs.create_queue(QueueName='eb-sqs-default')
 
         queue_client = SqsQueueClient()
@@ -27,7 +27,7 @@ class AwsQueueClientTest(TestCase):
     @mock_sqs()
     def test_add_message_delayed(self):
         delay = 1
-        sqs = boto3.resource('sqs', region_name=settings.AWS_REGION)
+        sqs = boto3.resource('sqs')
         queue = sqs.create_queue(QueueName='eb-sqs-default')
         queue_client = SqsQueueClient()
 

--- a/eb_sqs/tests/aws/tests_aws_queue_client.py
+++ b/eb_sqs/tests/aws/tests_aws_queue_client.py
@@ -1,13 +1,14 @@
 from __future__ import absolute_import, unicode_literals
 
-from unittest import TestCase
+import time
+from unittest import TestCase, skip
 
 import boto3
-import time
 from moto import mock_sqs
 
 from eb_sqs import settings
 from eb_sqs.aws.sqs_queue_client import SqsQueueClient
+from eb_sqs.worker.queue_client import QueueDoesNotExistException
 
 
 class AwsQueueClientTest(TestCase):
@@ -35,17 +36,17 @@ class AwsQueueClientTest(TestCase):
         queue.reload()
         self.assertEqual(queue.attributes["ApproximateNumberOfMessages"], '0')
 
-        time.sleep(delay+0.1)
+        time.sleep(delay + 0.1)
 
         queue.reload()
         self.assertEqual(queue.attributes["ApproximateNumberOfMessages"], '1')
 
-    # Disabled because current mock_sqs doesn't support invalid queue call
-    #@mock_sqs()
-    #def test_add_message_wrong_queue(self):
-    #    sqs = boto3.resource('sqs')
-    #    queue = sqs.create_queue(QueueName='default')
-    #    queue_client = SqsQueueClient()
-    #
-    #   with self.assertRaises(QueueDoesNotExistException):
-    #       queue_client.add_message('invalid', 'msg', 0)
+    @skip("Disabled because current mock_sqs doesn't support invalid queue call")
+    @mock_sqs()
+    def test_add_message_wrong_queue(self):
+        sqs = boto3.resource('sqs')
+        queue = sqs.create_queue(QueueName='default')
+        queue_client = SqsQueueClient()
+
+        with self.assertRaises(QueueDoesNotExistException):
+            queue_client.add_message('invalid', 'msg', 0)


### PR DESCRIPTION
Hi!
I opened this PR to fix an issue that I ran into while using this package.
Error message was:
```
botocore.exceptions.NoRegionError: You must specify a region.
```

- add explicit region_name to ```boto3.resource('sqs')``` call in SqsQueueClient
- adapt test

Let me know if you have a preference on how to work with PRs/Issues on Github.