### PR TITLE
BNCASB-2204: Adding PyPI version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 
+[![PyPI version](https://img.shields.io/pypi/v/django-eb-sqs)](https://img.shields.io/pypi/v/django-eb-sqs)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![CircleCI](https://img.shields.io/circleci/build/github/cuda-networks/django-eb-sqs/master)](https://circleci.com/gh/cuda-networks/django-eb-sqs/tree/master)
 


### PR DESCRIPTION
BNCASB-2204: Adding PyPI version badge to README